### PR TITLE
Improve button accessibility and responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -484,7 +484,7 @@ export default function ToolReviewMockup() {
       </div>
 
       {/* Fortschritt */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
         {["Stage 1", "Stage 2", "Stage 3", "Stage 4", "Stage 5"].map((stage, idx) => (
           <div key={idx} className="flex-1 flex flex-col items-center">
             <div className={`w-8 h-8 rounded-full flex items-center justify-center mb-2 ${idx < 3 ? "bg-pink-500 text-white" : "bg-gray-300"}`}>
@@ -495,9 +495,9 @@ export default function ToolReviewMockup() {
         ))}
       </div>
 
-      <div className="grid grid-cols-5 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
         {/* Sidebar */}
-        <div className="col-span-1">
+        <div className="col-span-1 md:col-span-1">
           <Card className="mb-4">
             <CardContent className="p-4 space-y-2">
               <div className="font-bold">Navigation</div>
@@ -567,7 +567,7 @@ export default function ToolReviewMockup() {
         </div>
 
         {/* Main Content */}
-        <div className="col-span-4">
+        <div className="col-span-1 md:col-span-4">
           <Card>
             <CardContent className="p-6 space-y-6">
               <div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from 'classnames'
+import cn from 'classnames'
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement>
 
@@ -7,12 +7,13 @@ export const Button = React.forwardRef<HTMLButtonElement, Props>(
   ({ className, ...props }, ref) => (
     <button
       ref={ref}
-      className={[
+      className={cn(
         'inline-flex items-center gap-2 rounded-md px-3.5 py-2 text-sm font-medium',
-        'bg-blue-600 hover:bg-blue-500 text-white',
+        'bg-pink-600 hover:bg-pink-500 text-white',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-pink-500',
         'disabled:opacity-60 disabled:pointer-events-none',
-        className || ''
-      ].join(' ')}
+        className
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- switch buttons to a higher-contrast pink theme with visible focus styles
- make progress indicator and main layout responsive for small screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4ebe7588832d9ce01ce32acb6562