### PR TITLE
Improve button accessibility and responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -484,7 +484,7 @@ export default function ToolReviewMockup() {
       </div>
 
       {/* Fortschritt */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
         {["Stage 1", "Stage 2", "Stage 3", "Stage 4", "Stage 5"].map((stage, idx) => (
           <div key={idx} className="flex-1 flex flex-col items-center">
             <div className={`w-8 h-8 rounded-full flex items-center justify-center mb-2 ${idx < 3 ? "bg-pink-500 text-white" : "bg-gray-300"}`}>
@@ -495,9 +495,9 @@ export default function ToolReviewMockup() {
         ))}
       </div>
 
-      <div className="grid grid-cols-5 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
         {/* Sidebar */}
-        <div className="col-span-1">
+        <div className="col-span-1 md:col-span-1">
           <Card className="mb-4">
             <CardContent className="p-4 space-y-2">
               <div className="font-bold">Navigation</div>
@@ -508,7 +508,7 @@ export default function ToolReviewMockup() {
                       <button
                         onClick={() => setActiveKey(key)}
                         className={`flex-1 flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition ${
-                          key === activeKey ? "bg-pink-50 text-pink-700 ring-1 ring-pink-200" : "hover:bg-gray-100"
+                          key === activeKey ? "bg-blue-50 text-blue-700 ring-1 ring-blue-200" : "hover:bg-gray-100"
                         }`}
                       >
                         <Icon size={14} />
@@ -551,7 +551,7 @@ export default function ToolReviewMockup() {
                     </span>
                   )}
                   {totalUnread > 0 && (
-                    <span className="text-xs rounded-full px-2 py-0.5 bg-pink-600 text-white">{totalUnread} neu</span>
+                    <span className="text-xs rounded-full px-2 py-0.5 bg-blue-600 text-white">{totalUnread} neu</span>
                   )}
                 </div>
               </div>
@@ -567,7 +567,7 @@ export default function ToolReviewMockup() {
         </div>
 
         {/* Main Content */}
-        <div className="col-span-4">
+        <div className="col-span-1 md:col-span-4">
           <Card>
             <CardContent className="p-6 space-y-6">
               <div>
@@ -634,7 +634,6 @@ export default function ToolReviewMockup() {
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-8 w-8"
                                 title={role.editing ? "Bearbeiten beenden" : "Bearbeiten"}
                                 onClick={(e) => {
                                   e.stopPropagation();
@@ -644,9 +643,8 @@ export default function ToolReviewMockup() {
                                 <Pencil size={16} />
                               </Button>
                               <Button
-                                variant="ghost"
+                                variant="danger"
                                 size="icon"
-                                className="h-8 w-8 text-red-600 hover:text-red-700"
                                 title="Löschen"
                                 onClick={(e) => {
                                   e.stopPropagation();
@@ -655,7 +653,7 @@ export default function ToolReviewMockup() {
                               >
                                 <Trash2 size={16} />
                               </Button>
-                              <Button variant="ghost" size="icon" className="h-8 w-8">
+                              <Button variant="ghost" size="icon">
                                 {role.expanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
                               </Button>
                             </div>
@@ -710,7 +708,7 @@ export default function ToolReviewMockup() {
                                     </div>
                                   </div>
                                   <div className="flex justify-end gap-2">
-                                    <Button variant="outline" onClick={() => toggleEdit(role.id)}>Abbrechen</Button>
+                                    <Button variant="neutral" onClick={() => toggleEdit(role.id)}>Abbrechen</Button>
                                     <Button onClick={() => toggleEdit(role.id)}>Speichern</Button>
                                   </div>
                                 </div>
@@ -802,7 +800,7 @@ export default function ToolReviewMockup() {
                       </div>
 
                       <div className="flex justify-end gap-2">
-                        <Button variant="outline" onClick={() => setBasis(makeInitialBasis())}>Zurücksetzen</Button>
+                        <Button variant="danger" onClick={() => setBasis(makeInitialBasis())}>Zurücksetzen</Button>
                         <Button onClick={() => localStorage.setItem("basis-info", JSON.stringify(basis))}>Speichern</Button>
                       </div>
                     </div>
@@ -830,28 +828,28 @@ export default function ToolReviewMockup() {
                   <div className="flex items-center gap-2">
                     <span className="text-xs text-gray-500">Ungelesen: {unreadBySection[activeKey] || 0}</span>
                     <Button
-                      variant="outline"
+                      variant="neutral"
                       size="sm"
                       onClick={() => setExpandedCommentSections((prev) => ({ ...prev, [activeKey]: !prev[activeKey] }))}
                     >
                       {expandedCommentSections[activeKey] ? "Kommentare ausblenden" : `Kommentare anzeigen (${(commentsBySection[activeKey] || []).length})`}
                     </Button>
                     <Button
-                      variant="ghost"
+                      variant="neutral"
                       size="sm"
                       onClick={() => setCollapsedComments((prev) => ({ ...prev, [activeKey]: true }))}
                       title="Alle Kommentare kompakt anzeigen"
                     >Alle einklappen</Button>
                     {collapsedComments[activeKey] && (
                       <Button
-                        variant="ghost"
+                        variant="neutral"
                         size="sm"
                         onClick={() => setCollapsedComments((prev) => ({ ...prev, [activeKey]: false }))}
                         title="Alle Kommentare wieder voll anzeigen"
                       >Alle ausklappen</Button>
                     )}
                     {unreadBySection[activeKey] > 0 && (
-                      <Button variant="ghost" size="sm" onClick={() => markAllReadInSection(activeKey)}>Alle als gelesen markieren</Button>
+                      <Button variant="neutral" size="sm" onClick={() => markAllReadInSection(activeKey)}>Alle als gelesen markieren</Button>
                     )}
                   </div>
                 </div>
@@ -907,10 +905,10 @@ export default function ToolReviewMockup() {
                                 </div>
                               )}
                               <div className="mt-2 flex items-center gap-2">
-                                <Button size="sm" variant="ghost" onClick={() => toggleRead(activeKey, c.id)}>
+                                <Button size="sm" variant="neutral" onClick={() => toggleRead(activeKey, c.id)}>
                                   {c.read ? "Als ungelesen markieren" : "Als gelesen markieren"}
                                 </Button>
-                                <Button size="sm" variant="ghost" onClick={() => addReply(activeKey, c.id, "@Max Danke! #HR")}>Antworten</Button>
+                                <Button size="sm" variant="neutral" onClick={() => addReply(activeKey, c.id, "@Max Danke! #HR")}>Antworten</Button>
                               </div>
                             </div>
                           </div>
@@ -929,7 +927,7 @@ export default function ToolReviewMockup() {
                           <div className="flex flex-wrap gap-2">
                             {mention.options.length ? (
                               mention.options.map((opt) => (
-                                <button key={opt} className="px-2 py-1 rounded-md bg-white border hover:bg-gray-100" onClick={() => insertMention(opt)}>
+                                <button key={opt} className="px-2 py-1 rounded-md bg-white border text-gray-700 hover:bg-gray-100" onClick={() => insertMention(opt)}>
                                   {mention.type}{opt}
                                 </button>
                               ))
@@ -971,7 +969,7 @@ export default function ToolReviewMockup() {
                       </div>
 
                       <div className="flex gap-2 justify-end">
-                        <Button variant="outline" onClick={() => setCommentDrafts((prev) => ({ ...prev, [activeKey]: { text: "", visibility: VISIBILITY.ALL } }))}>Zurücksetzen</Button>
+                        <Button variant="neutral" onClick={() => setCommentDrafts((prev) => ({ ...prev, [activeKey]: { text: "", visibility: VISIBILITY.ALL } }))}>Zurücksetzen</Button>
                         <Button
                           onClick={() => {
                             if (!currentDraft.text?.trim()) return;
@@ -1001,7 +999,7 @@ export default function ToolReviewMockup() {
                 <MessageSquare />
                 <h3 className="text-lg font-semibold">Alle Kommentare</h3>
               </div>
-              <Button variant="outline" onClick={() => setShowGlobalComments(false)}><X size={16} className="mr-1"/> Schließen</Button>
+              <Button variant="neutral" onClick={() => setShowGlobalComments(false)}><X size={16} className="mr-1"/> Schließen</Button>
             </div>
 
             {/* Filterleiste */}
@@ -1080,10 +1078,10 @@ export default function ToolReviewMockup() {
                       <td className="p-2 align-top">
                         <div className="flex justify-end gap-2">
                           <Button size="sm" variant="secondary" onClick={() => jumpToComment(sectionKey, c.id)}>Öffnen</Button>
-                          <Button size="sm" variant="outline" onClick={() => toggleRead(sectionKey, c.id)}>
+                          <Button size="sm" variant="neutral" onClick={() => toggleRead(sectionKey, c.id)}>
                             {c.read ? "Ungelesen" : "Gelesen"}
                           </Button>
-                          <Button size="sm" variant="outline" onClick={() => addReply(sectionKey, c.id, "Antwort aus Übersicht…")}>Antworten</Button>
+                          <Button size="sm" variant="neutral" onClick={() => addReply(sectionKey, c.id, "Antwort aus Übersicht…")}>Antworten</Button>
                         </div>
                       </td>
                     </tr>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,18 +1,48 @@
 import * as React from 'react'
-import { cn } from 'classnames'
+import cn from 'classnames'
 
-type Props = React.ButtonHTMLAttributes<HTMLButtonElement>
+type Variant = 'primary' | 'secondary' | 'danger' | 'neutral' | 'ghost'
+type Size = 'default' | 'sm' | 'icon'
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant
+  size?: Size
+}
+
+const variantClasses: Record<Variant, string> = {
+  primary:
+    'bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-blue-500',
+  secondary:
+    'bg-white text-blue-600 border border-blue-600 hover:bg-blue-50 focus-visible:ring-blue-500',
+  danger:
+    'bg-red-50 text-red-600 hover:bg-red-100 focus-visible:ring-red-500',
+  neutral:
+    'bg-gray-100 text-gray-700 hover:bg-gray-200 focus-visible:ring-gray-500',
+  ghost:
+    'bg-transparent text-blue-600 hover:bg-blue-50 focus-visible:ring-blue-500',
+}
+
+const sizeClasses: Record<Size, string> = {
+  default: 'px-3.5 py-2 text-sm',
+  sm: 'px-2.5 py-1.5 text-xs',
+  icon: 'h-8 w-8 justify-center p-0',
+}
 
 export const Button = React.forwardRef<HTMLButtonElement, Props>(
-  ({ className, ...props }, ref) => (
+  (
+    { className, variant = 'primary', size = 'default', ...props },
+    ref
+  ) => (
     <button
       ref={ref}
-      className={[
-        'inline-flex items-center gap-2 rounded-md px-3.5 py-2 text-sm font-medium',
-        'bg-blue-600 hover:bg-blue-500 text-white',
+      className={cn(
+        'inline-flex items-center gap-2 rounded-md font-medium',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
         'disabled:opacity-60 disabled:pointer-events-none',
-        className || ''
-      ].join(' ')}
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- introduce variant and size props to Button component for primary, secondary, neutral, danger and ghost styles
- apply new color palette to navigation and comment controls so actions are visually distinct

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4ebe7588832d9ce01ce32acb6562