### PR TITLE
feat: adjust responsive grid breakpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -495,7 +495,7 @@ export default function ToolReviewMockup() {
         ))}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
         {/* Sidebar */}
         <div className="col-span-1 md:col-span-1">
           <Card className="mb-4">
@@ -567,7 +567,7 @@ export default function ToolReviewMockup() {
         </div>
 
         {/* Main Content */}
-        <div className="col-span-1 md:col-span-4">
+        <div className="col-span-1 lg:col-span-4 min-w-0 overflow-x-auto">
           <Card>
             <CardContent className="p-6 space-y-6">
               <div>


### PR DESCRIPTION
## Summary
- switch grid layout to use `lg` breakpoint
- set main content column span to `lg:col-span-4` with overflow handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad584c5980832d8e93d6ac8ccd38d9