### PR TITLE
feat: add profile menu component

### DIFF
--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+
+export type UserContextValue = {
+  username: string;
+  roles: string[];
+  activeRole: string;
+  setActiveRole: (role: string) => void;
+  logout: () => void;
+};
+
+export const UserContext = createContext<UserContextValue>({
+  username: '',
+  roles: [],
+  activeRole: '',
+  setActiveRole: () => {},
+  logout: () => {},
+});

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -1,0 +1,46 @@
+import { useContext } from 'react';
+import { UserContext } from '@/UserContext';
+import { Button } from '@/components/ui/button';
+
+interface ProfileMenuProps {
+  onClose?: () => void;
+}
+
+export function ProfileMenu({ onClose }: ProfileMenuProps) {
+  const { username, roles, activeRole, setActiveRole, logout } = useContext(UserContext);
+
+  const handleRoleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setActiveRole(e.target.value);
+    onClose?.();
+  };
+
+  const handleLogout = () => {
+    logout();
+    onClose?.();
+  };
+
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <div className="font-semibold">{username}</div>
+      <label className="text-sm">
+        Rolle
+        <select
+          className="mt-1 block w-full border rounded"
+          value={activeRole}
+          onChange={handleRoleChange}
+        >
+          {roles.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </label>
+      <Button onClick={handleLogout} className="mt-2">
+        Logout
+      </Button>
+    </div>
+  );
+}
+
+export default ProfileMenu;


### PR DESCRIPTION
## Summary
- add ProfileMenu component leveraging UserContext for role switching and logout
- stub UserContext definition

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad6501aa6c832dab2c07db52668929