### PR TITLE
Add auth module with user context and role management

### DIFF
--- a/src/auth/UserContext.tsx
+++ b/src/auth/UserContext.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import authService, { Group, Role, User } from './authService';
+
+interface UserContextType {
+  user: User | null;
+  roles: Role[];
+  groups: Group[];
+  activeRole: string | null;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  setActiveRole: (roleId: string) => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [activeRole, setActiveRoleState] = useState<string | null>(() =>
+    localStorage.getItem('activeRole')
+  );
+
+  useEffect(() => {
+    authService.getSession().then((sessionUser) => {
+      if (sessionUser) {
+        setUser(sessionUser);
+        setRoles(sessionUser.roles);
+        setGroups(sessionUser.groups);
+      }
+    });
+  }, []);
+
+  const login = async (username: string, password: string) => {
+    const sessionUser = await authService.login(username, password);
+    setUser(sessionUser);
+    setRoles(sessionUser.roles);
+    setGroups(sessionUser.groups);
+    if (sessionUser.roles.length > 0) {
+      setActiveRole(sessionUser.roles[0].id);
+    }
+  };
+
+  const logout = async () => {
+    await authService.logout();
+    setUser(null);
+    setRoles([]);
+    setGroups([]);
+    setActiveRoleState(null);
+    localStorage.removeItem('activeRole');
+  };
+
+  const setActiveRole = (roleId: string) => {
+    setActiveRoleState(roleId);
+    localStorage.setItem('activeRole', roleId);
+  };
+
+  return (
+    <UserContext.Provider
+      value={{ user, roles, groups, activeRole, login, logout, setActiveRole }}
+    >
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = (): UserContextType => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+};

--- a/src/auth/authService.ts
+++ b/src/auth/authService.ts
@@ -1,0 +1,52 @@
+export interface Role {
+  id: string;
+  name: string;
+}
+
+export interface Group {
+  id: string;
+  name: string;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  roles: Role[];
+  groups: Group[];
+}
+
+const login = async (username: string, password: string): Promise<User> => {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    throw new Error('Login failed');
+  }
+  const data = await res.json();
+  localStorage.setItem('token', data.token);
+  return data.user as User;
+};
+
+const logout = async (): Promise<void> => {
+  await fetch('/api/logout', { method: 'POST' });
+  localStorage.removeItem('token');
+};
+
+const getSession = async (): Promise<User | null> => {
+  const res = await fetch('/api/session');
+  if (!res.ok) {
+    return null;
+  }
+  const data = await res.json();
+  return data.user as User;
+};
+
+export const authService = {
+  login,
+  logout,
+  getSession,
+};
+
+export default authService;

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,2 @@
+export * from './authService';
+export * from './UserContext';


### PR DESCRIPTION
## Summary
- add authentication service with login, logout and session functions
- create UserContext to hold user data, roles, groups and active role
- implement role switching that syncs with localStorage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad65006be8832da6c4216d1b41e5f3