### PR TITLE
Fix seeding for SQLite and adjust database path

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL="file:./prisma/dev.db"
+DATABASE_URL="file:./dev.db"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+dev.db
 prisma/dev.db

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -39,17 +39,22 @@ async function main() {
   })
 
   // RolePermissions
-  await prisma.rolePermission.createMany({
-    data: [
+  await Promise.all(
+    [
       { roleId: br.id, permissionId: read.id },
       { roleId: fso.id, permissionId: read.id },
       { roleId: fso.id, permissionId: write.id },
       { roleId: admin.id, permissionId: read.id },
       { roleId: admin.id, permissionId: write.id },
       { roleId: admin.id, permissionId: del.id },
-    ],
-    skipDuplicates: true,
-  })
+    ].map((rp) =>
+      prisma.rolePermission.upsert({
+        where: { roleId_permissionId: rp },
+        update: {},
+        create: rp,
+      })
+    )
+  )
 
   // User
   const hashed = await bcrypt.hash('Admin', 10)
@@ -64,9 +69,10 @@ async function main() {
   })
 
   // UserRole
-  await prisma.userRole.createMany({
-    data: [{ userId: max.id, roleId: admin.id }],
-    skipDuplicates: true,
+  await prisma.userRole.upsert({
+    where: { userId_roleId: { userId: max.id, roleId: admin.id } },
+    update: {},
+    create: { userId: max.id, roleId: admin.id },
   })
 
   console.log('✅ Seed abgeschlossen')


### PR DESCRIPTION
## Summary
- Use upserts for role permissions and user roles in seed script to avoid unsupported `skipDuplicates` on SQLite
- Store development database at project root and ignore it in git

## Testing
- `npm run prisma:migrate`
- `npm run prisma:seed`
- `curl -s -w '\n' -H 'Content-Type: application/json' -d '{"email":"max.mustermann@telekom.de","password":"Admin"}' http://localhost:3001/api/login`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aeb7bea9a0832d984607cfba55247f