### PR TITLE
Simplify Filebrowser login and remove Caddy auth

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -7,9 +7,7 @@
 }
 
 files.skyserver.online {
-  basicauth {
-    bjoern "$2a$10$57ht3xGKprEjkvF4lOG/R.z30F260EzlJhDZixvUt5QwnRf4kg8bu"   # Platzhalter (siehe unten)
-  }
+  # Authentication is handled by Filebrowser itself (see docker-compose.yml)
   reverse_proxy filebrowser:80
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,10 @@ services:
       - filebrowser_config:/config
     expose:
       - "80"
-    # optionales Start-Passwort / Benutzer via ENV:
-    # environment:
-    #   - FB_AUTH_METHOD=json
+    environment:
+      - FB_AUTH_METHOD=basic
+      - FB_USERNAME=Bjoern
+      - FB_PASSWORD=admin25
 
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
## Summary
- Remove Caddyfile's hashed `basicauth` block so Filebrowser handles authentication
- Clarify in `docker-compose.yml` the basic credentials for Filebrowser (Bjoern/admin25)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af238dbad4832d8c2a860fdbe7d40d