### PR TITLE
Enable AI notice checkbox and add additional fields

### DIFF
--- a/src/AITab.tsx
+++ b/src/AITab.tsx
@@ -34,7 +34,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
       autonomy: 'advice',
       hitl: { required: false, thresholds: '' },
       permission_dimensions: '',
-      transparency_notice: { required: false, artifact_link: '' },
+      transparency_notice: { required: false, notice_text: '', other_marking: '' },
       risk: { eu_ai_act: 'minimal', corp_class: 'low', justification: '' },
       dea: { completed: false, date: '', file: undefined },
       monitoring: { metrics: [], eval_cadence: '' },
@@ -43,7 +43,6 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
 
   const aiPresent = form.watch('ai_present');
   const corpClass = form.watch('risk.corp_class');
-  const employeeInteraction = form.watch('employee_interaction');
   const personalData = form.watch('personal_data_used');
 
   const onSubmit = (data: AiFormData) => {
@@ -197,12 +196,17 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
             <h2>F: {t("aiTab.transparency.label")}</h2>
             <p>{t("aiTab.transparency.description")}</p>
             <label className="flex items-center gap-2">
-              <Checkbox {...form.register('transparency_notice.required')} disabled={!employeeInteraction} /> {t("aiTab.transparencyNotice.label")}
+              <Checkbox {...form.register('transparency_notice.required')} /> {t("aiTab.transparencyNotice.label")}
             </label>
-            <label>{t("aiTab.transparencyNotice.artifactLink.label")}</label>
+            <label>{t("aiTab.transparencyNotice.noticeText.label")}</label>
             <Input
-              placeholder={t("aiTab.transparencyNotice.artifactLink.placeholder")}
-              {...form.register('transparency_notice.artifact_link')}
+              placeholder={t("aiTab.transparencyNotice.noticeText.placeholder")}
+              {...form.register('transparency_notice.notice_text')}
+            />
+            <label>{t("aiTab.transparencyNotice.otherMarking.label")}</label>
+            <Input
+              placeholder={t("aiTab.transparencyNotice.otherMarking.placeholder")}
+              {...form.register('transparency_notice.other_marking')}
             />
           </Card>
 

--- a/src/messages.de.json
+++ b/src/messages.de.json
@@ -76,7 +76,8 @@
     },
     "transparencyNotice": {
       "label": "KI-Hinweis im UI angezeigt",
-      "artifactLink": { "label": "Link zum Hinweis (falls vorhanden)", "placeholder": "Link" }
+      "noticeText": { "label": "Hinweistext (falls bereits vorhanden)", "placeholder": "Hinweistext" },
+      "otherMarking": { "label": "Sonstige Kennzeichnung", "placeholder": "Sonstige Kennzeichnung" }
     },
     "risk": {
       "label": "Risiko",

--- a/src/mock/ai.mock.ts
+++ b/src/mock/ai.mock.ts
@@ -13,7 +13,7 @@ export const lowRisk: AiFormData = {
   autonomy: 'advice',
   hitl: { required: false, thresholds: '' },
   permission_dimensions: '',
-  transparency_notice: { required: false, artifact_link: '' },
+  transparency_notice: { required: false, notice_text: '', other_marking: '' },
   risk: { eu_ai_act: 'minimal', corp_class: 'low', justification: 'minimal risk' },
   dea: { uploaded: true, date: '2024-01-01', link: '' },
   monitoring: { metrics: ['accuracy'], eval_cadence: '' },

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -34,7 +34,8 @@ export const aiSchema = z.object({
   permission_dimensions: z.string().optional(),
   transparency_notice: z.object({
     required: z.boolean(),
-    artifact_link: z.string().url().optional(),
+    notice_text: z.string().optional(),
+    other_marking: z.string().optional(),
   }),
   risk: z.object({
     eu_ai_act: z.enum(['minimal', 'limited', 'high', 'prohibited']),
@@ -55,8 +56,8 @@ export const aiSchema = z.object({
     if (!data.transparency_notice.required) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['transparency_notice', 'required'], message: 'required' });
     }
-    if (!data.transparency_notice.artifact_link) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['transparency_notice', 'artifact_link'], message: 'link required' });
+    if (!data.transparency_notice.notice_text) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['transparency_notice', 'notice_text'], message: 'text required' });
     }
   }
 


### PR DESCRIPTION
## Summary
- allow the KI notice checkbox to be toggled
- replace notice link with text field and add optional "Sonstige Kennzeichnung"
- update schema, translations, and mocks accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b01b0ad5cc832da0fea77b780b79eb