### PR TITLE
feat: use rich text for thresholds and permissions

### DIFF
--- a/src/AITab.tsx
+++ b/src/AITab.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { aiSchema, AiFormData } from './schema';
 import { Input } from './components/ui/input';
 import { Checkbox } from './components/ui/checkbox';
 import { Textarea } from './components/ui/textarea';
+import { RichTextarea } from './components/ui/rich-textarea';
 import { Button } from './components/ui/button';
 import { t } from "./i18n";
 import { Select } from './components/ui/select';
@@ -178,15 +179,27 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
             </label>
             <div className="space-y-2 pl-4">
               <label>{t("aiTab.hitl.thresholds.label")}</label>
-              <Input
-                placeholder={t("aiTab.hitl.thresholds.placeholder")}
-                {...form.register('hitl.thresholds')}
+              <Controller
+                name="hitl.thresholds"
+                control={form.control}
+                render={({ field }) => (
+                  <RichTextarea
+                    placeholder={t("aiTab.hitl.thresholds.placeholder")}
+                    {...field}
+                  />
+                )}
               />
               <p className="text-sm text-neutral-600">{t("aiTab.hitl.thresholds.help")}</p>
               <label>{t("aiTab.permissionDimensions.label")}</label>
-              <Input
-                placeholder={t("aiTab.permissionDimensions.placeholder")}
-                {...form.register('permission_dimensions')}
+              <Controller
+                name="permission_dimensions"
+                control={form.control}
+                render={({ field }) => (
+                  <RichTextarea
+                    placeholder={t("aiTab.permissionDimensions.placeholder")}
+                    {...field}
+                  />
+                )}
               />
               <p className="text-sm text-neutral-600">{t("aiTab.permissionDimensions.help")}</p>
             </div>

--- a/src/components/ui/rich-textarea.tsx
+++ b/src/components/ui/rich-textarea.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+type Props = React.HTMLAttributes<HTMLDivElement> & {
+  value?: string
+  onChange?: (value: string) => void
+  placeholder?: string
+}
+
+export const RichTextarea = React.forwardRef<HTMLDivElement, Props>(
+  ({ value, onChange, className, ...props }, ref) => {
+    const { placeholder, ...rest } = props
+    const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
+      onChange?.(e.currentTarget.innerHTML)
+    }
+    return (
+      <div
+        ref={ref}
+        className={[
+          'w-full rounded-md border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm',
+          'placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-blue-600',
+          'min-h-[96px]',
+          'whitespace-pre-wrap',
+          'empty:before:content-[attr(data-placeholder)] before:text-neutral-400 before:pointer-events-none',
+          className || '',
+        ].join(' ')}
+        contentEditable
+        onInput={handleInput}
+        dangerouslySetInnerHTML={{ __html: value || '' }}
+        data-placeholder={placeholder as any}
+        {...rest}
+      />
+    )
+  }
+)
+RichTextarea.displayName = 'RichTextarea'


### PR DESCRIPTION
## Summary
- add RichTextarea component for rich text input
- switch HITL thresholds and permission dimensions to rich text fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b02e4a5d6c832dae6fe11a27a8195f