### PR TITLE
Add interactive status steps and rich text toolbar

### DIFF
--- a/src/AITab.tsx
+++ b/src/AITab.tsx
@@ -178,6 +178,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                 render={({ field }) => (
                   <RichTextarea
                     placeholder={t("aiTab.hitl.thresholds.placeholder")}
+                    toolbar
                     {...field}
                   />
                 )}
@@ -190,6 +191,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                 render={({ field }) => (
                   <RichTextarea
                     placeholder={t("aiTab.permissionDimensions.placeholder")}
+                    toolbar
                     {...field}
                   />
                 )}
@@ -210,6 +212,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
               render={({ field }) => (
                 <RichTextarea
                   placeholder={t("aiTab.transparencyNotice.noticeText.placeholder")}
+                  toolbar
                   {...field}
                 />
               )}
@@ -221,6 +224,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
               render={({ field }) => (
                 <RichTextarea
                   placeholder={t("aiTab.transparencyNotice.otherMarking.placeholder")}
+                  toolbar
                   {...field}
                 />
               )}
@@ -249,6 +253,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
               render={({ field }) => (
                 <RichTextarea
                   placeholder={t("aiTab.risk.justification.placeholder")}
+                  toolbar
                   {...field}
                 />
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,7 +238,7 @@ function HighlightedText({ text }: { text: string }) {
 
 export default function ToolReviewMockup() {
   const hasRole = (_role: string) => true;
-  const currentStage = 2; // 0-based index of the current status
+  const [currentStage, setCurrentStage] = useState(2); // 0-based index of the current status
   // active Tab
   const [activeKey, setActiveKey] = useState(NAV_ITEMS[0].key);
 
@@ -533,16 +533,27 @@ export default function ToolReviewMockup() {
       {/* Fortschritt */}
       <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
         {STAGES.map((stage, idx) => {
-          const statusIcon =
-            idx < currentStage ? <CheckCircle size={18} /> :
-            idx === currentStage ? <PlayCircle size={18} /> :
-            <Circle size={18} />;
-          const bgClass =
-            idx < currentStage ? "bg-pink-500 text-white" :
-            idx === currentStage ? "bg-blue-500 text-white" :
-            "bg-gray-300 text-gray-600";
+          const isApproved = currentStage === STAGES.length - 1;
+          const isDone = idx < currentStage || (isApproved && idx <= currentStage);
+          const isCurrent = idx === currentStage && !isApproved;
+          const statusIcon = isDone
+            ? <CheckCircle size={18} />
+            : isCurrent
+              ? <PlayCircle size={18} />
+              : <Circle size={18} />;
+          const bgClass = isDone
+            ? isApproved
+              ? "bg-green-500 text-white"
+              : "bg-pink-500 text-white"
+            : isCurrent
+              ? "bg-blue-500 text-white"
+              : "bg-gray-300 text-gray-600";
           return (
-            <div key={idx} className="flex-1 flex flex-col items-center">
+            <div
+              key={idx}
+              className="flex-1 flex flex-col items-center cursor-pointer"
+              onClick={() => setCurrentStage(idx)}
+            >
               <div className={`w-8 h-8 rounded-full flex items-center justify-center mb-2 ${bgClass}`}>
                 {statusIcon}
               </div>

--- a/src/components/ui/rich-textarea.tsx
+++ b/src/components/ui/rich-textarea.tsx
@@ -1,35 +1,113 @@
 import * as React from 'react'
+import { Button } from './button'
 
 type Props = React.HTMLAttributes<HTMLDivElement> & {
   value?: string
   onChange?: (value: string) => void
   placeholder?: string
+  toolbar?: boolean
 }
 
 export const RichTextarea = React.forwardRef<HTMLDivElement, Props>(
-  ({ value, onChange, className, ...props }, ref) => {
+  ({ value, onChange, className, toolbar, ...props }, ref) => {
     const { placeholder, ...rest } = props
+    const editorRef = React.useRef<HTMLDivElement>(null)
+
     const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
       onChange?.(e.currentTarget.innerHTML)
     }
+
+    const exec = (cmd: string) => {
+      document.execCommand(cmd)
+      onChange?.(editorRef.current?.innerHTML || '')
+    }
+
+    const setRefs = (node: HTMLDivElement | null) => {
+      editorRef.current = node
+      if (typeof ref === 'function') ref(node)
+      else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node
+    }
+
     return (
-      <div
-        ref={ref}
-        className={[
-          'w-full rounded-md border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm',
-          'placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-blue-600',
-          'min-h-[96px]',
-          'whitespace-pre-wrap',
-          'empty:before:content-[attr(data-placeholder)] before:text-neutral-400 before:pointer-events-none',
-          className || '',
-        ].join(' ')}
-        contentEditable
-        onInput={handleInput}
-        dangerouslySetInnerHTML={{ __html: value || '' }}
-        data-placeholder={placeholder as any}
-        {...rest}
-      />
+      <div className="w-full">
+        {toolbar && (
+          <div className="mb-2 flex flex-wrap gap-1 border-b pb-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                exec('bold')
+              }}
+            >
+              <b>B</b>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                exec('italic')
+              }}
+            >
+              <i>I</i>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                exec('underline')
+              }}
+            >
+              <u>U</u>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                exec('insertUnorderedList')
+              }}
+            >
+              &bull;
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                exec('insertOrderedList')
+              }}
+            >
+              1.
+            </Button>
+          </div>
+        )}
+        <div
+          ref={setRefs}
+          className={[
+            'w-full rounded-md border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm',
+            'placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-blue-600',
+            'min-h-[96px]',
+            'whitespace-pre-wrap',
+            'empty:before:content-[attr(data-placeholder)] before:text-neutral-400 before:pointer-events-none',
+            className || '',
+          ].join(' ')}
+          contentEditable
+          onInput={handleInput}
+          dangerouslySetInnerHTML={{ __html: value || '' }}
+          data-placeholder={placeholder as any}
+          {...rest}
+        />
+      </div>
     )
   }
 )
 RichTextarea.displayName = 'RichTextarea'
+


### PR DESCRIPTION
## Summary
- make progress status indicators clickable and turn all checks green once approved
- add optional formatting toolbar to RichTextarea and enable it across AI form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b19ae50d80832dbb9a21239d2028b2