### PR TITLE
fix: show list markers in rich text

### DIFF
--- a/src/components/ui/rich-textarea.tsx
+++ b/src/components/ui/rich-textarea.tsx
@@ -18,6 +18,7 @@ export const RichTextarea = React.forwardRef<HTMLDivElement, Props>(
     }
 
     const exec = (cmd: string) => {
+      editorRef.current?.focus()
       document.execCommand(cmd)
       onChange?.(editorRef.current?.innerHTML || '')
     }
@@ -97,6 +98,7 @@ export const RichTextarea = React.forwardRef<HTMLDivElement, Props>(
             'min-h-[96px]',
             'whitespace-pre-wrap',
             'empty:before:content-[attr(data-placeholder)] before:text-neutral-400 before:pointer-events-none',
+            'rich-text',
             className || '',
           ].join(' ')}
           contentEditable

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,11 @@
 .panel {
   @apply bg-[var(--panel)] border border-[var(--border)] rounded-xl;
 }
+
+.rich-text ul {
+  @apply list-disc pl-4;
+}
+
+.rich-text ol {
+  @apply list-decimal pl-4;
+}


### PR DESCRIPTION
## Summary
- ensure exec commands refocus the rich textarea before applying
- style unordered/ordered lists so bullet markers appear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b19d9c50a0832d9dc90afa78fe6021