### PR TITLE
Restrict BR editing on AI tab

### DIFF
--- a/src/AITab.tsx
+++ b/src/AITab.tsx
@@ -14,12 +14,13 @@ import CollapsibleCard from './components/ui/collapsible-card';
 interface Props {
   lastSnapshot?: Partial<AiFormData>;
   onCreateCR?: (tasks: string[]) => void;
+  canEdit?: boolean;
 }
 
 const corpRank = { low: 0, medium: 1, high: 2 } as const;
 const autoRank = { advice: 0, partial: 1, autonomous: 2 } as const;
 
-export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
+export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR, canEdit = true }) => {
   const form = useForm<AiFormData>({
     resolver: zodResolver(aiSchema),
     defaultValues: {
@@ -72,6 +73,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <fieldset disabled={!canEdit} className="space-y-4">
       <CollapsibleCard title={`A: ${t("aiTab.aiPresent.label")}`}>
         <p>{t("aiTab.aiPresent.description")}</p>
         <label className="flex items-center gap-2">
@@ -179,6 +181,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                   <RichTextarea
                     placeholder={t("aiTab.hitl.thresholds.placeholder")}
                     toolbar
+                    disabled={!canEdit}
                     {...field}
                   />
                 )}
@@ -192,6 +195,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                   <RichTextarea
                     placeholder={t("aiTab.permissionDimensions.placeholder")}
                     toolbar
+                    disabled={!canEdit}
                     {...field}
                   />
                 )}
@@ -213,6 +217,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                 <RichTextarea
                   placeholder={t("aiTab.transparencyNotice.noticeText.placeholder")}
                   toolbar
+                  disabled={!canEdit}
                   {...field}
                 />
               )}
@@ -225,6 +230,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                 <RichTextarea
                   placeholder={t("aiTab.transparencyNotice.otherMarking.placeholder")}
                   toolbar
+                  disabled={!canEdit}
                   {...field}
                 />
               )}
@@ -254,6 +260,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
                 <RichTextarea
                   placeholder={t("aiTab.risk.justification.placeholder")}
                   toolbar
+                  disabled={!canEdit}
                   {...field}
                 />
               )}
@@ -291,6 +298,7 @@ export const AITab: React.FC<Props> = ({ lastSnapshot, onCreateCR }) => {
         </>
       )}
       <Button type="submit">{t("aiTab.submit")}</Button>
+      </fieldset>
     </form>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1039,7 +1039,7 @@ export default function ToolReviewMockup() {
                     </div>
                   </fieldset>
                 ) : activeKey === "ai" ? (
-                  <AITab />
+                  <AITab canEdit={canEdit} />
                 ) : (
                   <div className="rounded-md border p-4 text-sm text-gray-600 bg-white">
                     Inhalt für <span className="font-medium">{activeItem.label}</span>

--- a/src/components/ui/rich-textarea.tsx
+++ b/src/components/ui/rich-textarea.tsx
@@ -6,10 +6,11 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   onChange?: (value: string) => void
   placeholder?: string
   toolbar?: boolean
+  disabled?: boolean
 }
 
 export const RichTextarea = React.forwardRef<HTMLDivElement, Props>(
-  ({ value, onChange, className, toolbar, ...props }, ref) => {
+  ({ value, onChange, className, toolbar, disabled, ...props }, ref) => {
     const { placeholder, ...rest } = props
     const editorRef = React.useRef<HTMLDivElement>(null)
 
@@ -108,9 +109,10 @@ export const RichTextarea = React.forwardRef<HTMLDivElement, Props>(
             'whitespace-pre-wrap',
             'empty:before:content-[attr(data-placeholder)] before:text-neutral-400 before:pointer-events-none',
             'rich-text',
+            disabled ? 'opacity-60 pointer-events-none' : '',
             className || '',
           ].join(' ')}
-          contentEditable
+          contentEditable={!disabled}
           onInput={handleInput}
           dangerouslySetInnerHTML={{ __html: value || '' }}
           data-placeholder={placeholder as any}


### PR DESCRIPTION
## Summary
- Pass editing permission to AI tab so only F.SysV or HR can modify fields
- Add optional `canEdit` flag to AI tab and disable form controls when read-only
- Extend rich text component with `disabled` support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2df978014832db4cfe1532644cc12