### PR TITLE
feat: add system detail view and branding

### DIFF
--- a/public/grip-logo.svg
+++ b/public/grip-logo.svg
@@ -1,0 +1,9 @@
+<svg width="200" height="80" viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+  <path d="M60 60H40a12 12 0 110-24 18 18 0 0136-4 14 14 0 1128 8h-8" stroke="#E20074" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="68" y="48" width="12" height="12" fill="#E20074"/>
+  <rect x="100" y="48" width="12" height="12" fill="#E20074"/>
+  <rect x="100" y="16" width="12" height="12" fill="#E20074"/>
+  <line x1="80" y1="54" x2="100" y2="54" stroke="#E20074" stroke-width="4"/>
+  <line x1="106" y1="48" x2="106" y2="28" stroke="#E20074" stroke-width="4"/>
+  <text x="120" y="60" fill="#E20074" font-size="32" font-family="Arial, sans-serif" font-weight="bold">GRIP</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import StartPage, { Role } from './StartPage'
 import ManualSystemFormPage from './ManualSystemFormPage'
 import GuidedSystemPlaceholder from './GuidedSystemPlaceholder'
 import AgendaPlaceholder from './AgendaPlaceholder'
+import type { System } from './mock/systems'
 
  type Page =
   | 'start'
@@ -10,19 +11,33 @@ import AgendaPlaceholder from './AgendaPlaceholder'
   | 'guided-system'
   | 'guided-agenda'
   | 'manual-agenda'
+  | 'system-detail'
 
 export default function App() {
   const [role, setRole] = useState<Role>('FSysV')
   const [page, setPage] = useState<Page>('start')
+  const [selectedSystem, setSelectedSystem] = useState<System | undefined>(undefined)
 
   const goStart = () => setPage('start')
 
-  if (page === 'manual-system') return <ManualSystemFormPage onBack={goStart} />
+  if (page === 'manual-system') return <ManualSystemFormPage onBack={goStart} role={role} />
+  if (page === 'system-detail' && selectedSystem)
+    return <ManualSystemFormPage onBack={goStart} role={role} system={selectedSystem} />
   if (page === 'guided-system') return <GuidedSystemPlaceholder onBack={goStart} />
   if (page === 'guided-agenda')
     return <AgendaPlaceholder onBack={goStart} title="Geführter Dialog - Tagesordnung" />
   if (page === 'manual-agenda')
     return <AgendaPlaceholder onBack={goStart} title="Manuelle Tagesordnung" />
 
-  return <StartPage role={role} onRoleChange={setRole} navigate={setPage} />
+  return (
+    <StartPage
+      role={role}
+      onRoleChange={setRole}
+      navigate={setPage}
+      onSelectSystem={(s) => {
+        setSelectedSystem(s)
+        setPage('system-detail')
+      }}
+    />
+  )
 }

--- a/src/ManualForm.tsx
+++ b/src/ManualForm.tsx
@@ -48,6 +48,8 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import cn from 'classnames'
 import AITab from './AITab'
+import type { Role } from './StartPage'
+import type { System } from './mock/systems'
 
 
 // Navigationseinträge
@@ -242,17 +244,22 @@ function HighlightedText({ text }: { text: string }) {
   );
 }
 
-export default function ManualForm() {
+interface ManualFormProps {
+  system?: System
+  role: Role
+}
+
+export default function ManualForm({ system, role }: ManualFormProps) {
   const [user, setUser] = useState({
     name: 'Ich',
     avatar: '',
     roles: ['BR', 'F.SysV', 'HR'],
     groups: ['Architektur-Team'],
-    currentRole: 'BR',
+    currentRole: role,
   });
   const [showProfile, setShowProfile] = useState(false);
-  const hasRole = (role: string) => user.currentRole === role;
-  const canEdit = hasRole('F.SysV') || hasRole('HR');
+  const hasRole = (r: string) => role === r;
+  const canEdit = role === 'FSysV';
   const [currentStage, setCurrentStage] = useState(2); // 0-based index of the current status
   // active Tab
   const [activeKey, setActiveKey] = useState(NAV_ITEMS[0].key);
@@ -265,7 +272,18 @@ export default function ManualForm() {
 
   // Basisinformationen State
   const [basis, setBasis] = useState<BasisInfo>(() => {
-    const saved = localStorage.getItem("basis-info");
+    if (system) {
+      const initial = makeInitialBasis();
+      return {
+        ...initial,
+        shortName: system.shortName,
+        longName: system.longName,
+        psi: system.categories.basis.psi,
+        appId: system.categories.basis.appId,
+        shortDescription: system.categories.basis.shortDescription,
+      };
+    }
+    const saved = localStorage.getItem('basis-info');
     return saved ? JSON.parse(saved) : makeInitialBasis();
   });
 

--- a/src/ManualSystemFormPage.tsx
+++ b/src/ManualSystemFormPage.tsx
@@ -1,7 +1,15 @@
 import ManualForm from './ManualForm'
 import { Button } from './components/ui/button'
+import type { System } from './mock/systems'
+import type { Role } from './StartPage'
 
-export default function ManualSystemFormPage({ onBack }: { onBack: () => void }) {
+interface Props {
+  onBack: () => void
+  system?: System
+  role: Role
+}
+
+export default function ManualSystemFormPage({ onBack, system, role }: Props) {
   return (
     <div>
       <div className="p-4">
@@ -9,7 +17,7 @@ export default function ManualSystemFormPage({ onBack }: { onBack: () => void })
           Zurück
         </Button>
       </div>
-      <ManualForm />
+      <ManualForm system={system} role={role} />
     </div>
   )
 }

--- a/src/StartPage.tsx
+++ b/src/StartPage.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from './components/ui/card'
 import { Button } from './components/ui/button'
 import { systems } from './mock/systems'
+import type { System } from './mock/systems'
 import { sessions } from './mock/sessions'
 
 export type Role = 'FSysV' | 'BR'
@@ -12,9 +13,10 @@ interface Props {
   role: Role
   onRoleChange: (r: Role) => void
   navigate: (page: string) => void
+  onSelectSystem: (s: System) => void
 }
 
-export default function StartPage({ role, onRoleChange, navigate }: Props) {
+export default function StartPage({ role, onRoleChange, navigate, onSelectSystem }: Props) {
   const mySystems = systems.filter(
     (s) => s.createdBy === CURRENT_USER || s.fso === CURRENT_USER
   )
@@ -23,6 +25,18 @@ export default function StartPage({ role, onRoleChange, navigate }: Props) {
 
   return (
     <div className="p-6 space-y-6">
+      <div className="flex items-center space-x-4">
+        <img src="/grip-logo.svg" alt="GRIP Logo" className="h-12" />
+        <h1 className="text-2xl font-bold text-neutral-800">
+          <span className="text-[#E20074]">GR</span>
+          <span className="text-neutral-800">emien‑</span>
+          <span className="text-[#E20074]">I</span>
+          <span className="text-neutral-800">ntegrations‑</span>
+          <span className="text-[#E20074]">P</span>
+          <span className="text-neutral-800">lattform</span>
+        </h1>
+      </div>
+
       <div className="flex items-center space-x-2">
         <label className="text-sm font-medium">Rolle:</label>
         <select
@@ -55,7 +69,12 @@ export default function StartPage({ role, onRoleChange, navigate }: Props) {
               <ul className="list-disc list-inside text-sm space-y-1">
                 {mySystems.map((s) => (
                   <li key={s.id}>
-                    {s.shortName} – {s.categories.basis.shortDescription}
+                    <button
+                      onClick={() => onSelectSystem(s)}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {s.shortName} – {s.categories.basis.shortDescription}
+                    </button>
                   </li>
                 ))}
               </ul>
@@ -83,7 +102,14 @@ export default function StartPage({ role, onRoleChange, navigate }: Props) {
               <h2 className="text-xl font-semibold mb-2">Systemgruppe</h2>
               <ul className="list-disc list-inside text-sm space-y-1">
                 {groupSystems.map((s) => (
-                  <li key={s.id}>{s.shortName}</li>
+                  <li key={s.id}>
+                    <button
+                      onClick={() => onSelectSystem(s)}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {s.shortName}
+                    </button>
+                  </li>
                 ))}
               </ul>
             </CardContent>


### PR DESCRIPTION
## Summary
- make start page show GRIP branding and clickable dummy systems
- add detail view using manual form with role-based edit permissions
- include GRIP logo asset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92734458c832d99c7526f9d5ec030