### PR TITLE
fix: restore AI tab rendering

### DIFF
--- a/src/AITab.tsx
+++ b/src/AITab.tsx
@@ -10,6 +10,8 @@ import { Button } from './components/ui/button';
 import { useTranslation } from 'react-i18next';
 import { Select } from './components/ui/select';
 import CollapsibleCard from './components/ui/collapsible-card';
+import PurposeSection from './ai-tab/PurposeSection';
+import DataSection from './ai-tab/DataSection';
 
 interface Props {
   lastSnapshot?: Partial<AiFormData>;


### PR DESCRIPTION
## Summary
- import PurposeSection and DataSection into AITab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b944660b10832da01df3c0bf33d968