### PR TITLE
Add reports tab layout and shared section banners

### DIFF
--- a/src/manual-form/nav-items.ts
+++ b/src/manual-form/nav-items.ts
@@ -5,7 +5,7 @@ export const NAV_ITEMS = [
   { key: 'system', label: 'Systembeschreibung', Icon: Cog },
   { key: 'apis', label: 'Schnittstellen', Icon: Share2 },
   { key: 'roles', label: 'Rollen / Berechtigungen', Icon: UserCog },
-  { key: 'reports', label: 'Auswertungen / Reports', Icon: BarChart3 },
+  { key: 'reports', label: 'Reports / Auswertungen / Anzeigen', Icon: BarChart3 },
   { key: 'privacy', label: 'Datenschutz / Compliance', Icon: Lock },
   { key: 'ai', label: 'Künstliche Intelligenz', Icon: Bot },
 ] as const;


### PR DESCRIPTION
## Summary
- add reusable gradient section banner for all tabs with descriptive text
- build out the reports tab with provided data points, conditional questions, and export settings
- update navigation label to the new "Reports / Auswertungen / Anzeigen" wording

## Testing
- `npm test -- --runInBand` *(fails: npm command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d94eafc8832da125dde869c70d7b)